### PR TITLE
Filter out the front-end learn plan list

### DIFF
--- a/common/view/finder.view.js
+++ b/common/view/finder.view.js
@@ -13,9 +13,13 @@ import { getQuestionListCodeBySlug } from '#common/utils/question-handler/getQue
 import { getQuestionTagType } from '#common/utils/question-getter/getQuestionTagType.js'
 
 function handleQuestionList(list) {
-  let questionList = []
+  const questionList = []
   list.forEach((item) => {
-    if (!item.premiumOnly && item.name.indexOf('SQL') <= -1 && item.name.indexOf('Pandas') <= -1) {
+    if (
+      !item.premiumOnly &&
+      item.name.indexOf('SQL') <= -1 &&
+      item.name.indexOf('Pandas') <= -1
+    ) {
       questionList.push({
         name: `${item.name}(${item.questionNum}题)`,
         value: item.slug

--- a/common/view/finder.view.js
+++ b/common/view/finder.view.js
@@ -13,23 +13,29 @@ import { getQuestionListCodeBySlug } from '#common/utils/question-handler/getQue
 import { getQuestionTagType } from '#common/utils/question-getter/getQuestionTagType.js'
 
 function handleQuestionList(list) {
-  return list.map((item) => ({
-    name: `${item.name}${item.premiumOnly ? '(VIP)' : ''}`,
-    value: item.slug
-  }))
+  let questionList = []
+  list.forEach((item) => {
+    if (!item.premiumOnly && item.name.indexOf('SQL') <= -1 && item.name.indexOf('Pandas') <= -1) {
+      questionList.push({
+        name: `${item.name}(${item.questionNum}题)`,
+        value: item.slug
+      })
+    }
+  })
+  return questionList
 }
 
 async function studyMode(baseDir = process.cwd()) {
-  const sprintInterviewCompanyList = await getStudyPlanList(
-    'sprint-interview-company'
-  )
+  // const sprintInterviewCompanyList = await getStudyPlanList(
+  //   'sprint-interview-company'
+  // )
   const crackingCodingInterviewList = await getStudyPlanList(
     'cracking-coding-interview'
   )
   const deepDiveTopicsList = await getStudyPlanList('deep-dive-topics')
   const questionList = [
-    ...handleQuestionList(sprintInterviewCompanyList),
-    new Separator(),
+    // ...handleQuestionList(sprintInterviewCompanyList),
+    // new Separator(),
     ...handleQuestionList(crackingCodingInterviewList),
     new Separator(),
     ...handleQuestionList(deepDiveTopicsList)


### PR DESCRIPTION
Currently, there are many learning plan lists that are not related to the front-end that are searched using LF. A list of unrelated questions such as SQL and Pandas has been filtered out.

<img width="1130" alt="image" src="https://github.com/EternalHeartTeam/leetcode-practice/assets/61453917/7eefdec1-0358-45ca-8c6e-11261d8e561e">
